### PR TITLE
Add psse_to_Network parser

### DIFF
--- a/src/CommonOPF.jl
+++ b/src/CommonOPF.jl
@@ -77,6 +77,7 @@ export
 
     # io
     dss_to_Network,
+    psse_to_Network,
 
     # network reduction
     reduce_tree!,

--- a/test/test_psse.jl
+++ b/test/test_psse.jl
@@ -9,11 +9,17 @@
     first_tr = first(trs)
     @test isapprox(first_tr[:reactance], 0.02670 * (138^2 / 100); atol=1e-6)
 
-    loads = CommonOPF.ieee118_load_data(fp)
+    net = CommonOPF.psse_to_Network(fp)
+    @test net.substation_bus == "1"
+    @test length(conductors(net)) == length(cds)
+    @test net["1"][:Load].kws1 == [17000.0]
+    @test net["1"][:Generator].mva_base == 100.0
+
+    loads = CommonOPF.psse_load_data(fp)
     @test loads[1][:bus] == "1"
     @test loads[1][:kws1] == [17000.0]
 
-    gens = CommonOPF.ieee118_generator_data(fp)
+    gens = CommonOPF.psse_generator_data(fp)
     @test gens[1][:bus] == "1"
     @test gens[1][:mva_base] == 100.0
 


### PR DESCRIPTION
## Summary
- implement `psse_to_Network` for converting a RAW file directly into a `Network`
- rename `ieee118_generator_data` and `ieee118_load_data` to `psse_generator_data` and `psse_load_data`
- export `psse_to_Network`
- test the new parser along with renamed helpers

## Testing
- `julia --project=test -e 'using Pkg; Pkg.test()'` *(fails: could not download registry)*

------
https://chatgpt.com/codex/tasks/task_b_686034930bf4832f92f079db2d3dd842