### PR TITLE
Support parallel conductors

### DIFF
--- a/docs/src/developer/developer.md
+++ b/docs/src/developer/developer.md
@@ -61,6 +61,9 @@ import InteractiveUtils: subtypes # hide
 
 subtypes(CommonOPF.AbstractEdge)
 ```
+`ParallelConductor` is used internally when multiple `Conductor` specifications
+share the same pair of busses. The impedance and admittance methods operate on a
+`ParallelConductor` just like a single `Conductor`.
 To add a new Edge device:
 1. create `YourType` that has at a minimum:
     ```julia

--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -13,6 +13,11 @@ include:
 - [VoltageRegulator](@ref)
 - [Transformer](@ref)
 
+Duplicate conductor entries between the same pair of busses are automatically
+stored as a `ParallelConductor`. Impedance and admittance functions treat a
+`ParallelConductor` the same as a single conductor whose parameters are the
+parallel combination of the contained lines.
+
 Within the network model edges are indexed via two-tuples of bus names like so:
 ```@example
 using CommonOPF

--- a/src/edges/admittances.jl
+++ b/src/edges/admittances.jl
@@ -268,6 +268,44 @@ function susceptance(c::Conductor, phase_type::Type{T}) where {T <: Phases}
     susceptance_per_length(c, phase_type) * c.length
 end
 
+function _parallel_admittance(pc::ParallelConductor, phase_type::Type{SinglePhase})
+    y = zero(ComplexF64)
+    for c in pc.conductors
+        z = resistance(c, phase_type) + im * reactance(c, phase_type)
+        y += 1 / z
+    end
+    return y
+end
+
+function _parallel_admittance(pc::ParallelConductor, phase_type::Type{MultiPhase})
+    Y = zeros(ComplexF64, 3, 3)
+    for c in pc.conductors
+        z = resistance(c, phase_type) + im * reactance(c, phase_type)
+        Y .+= inverse_matrix_with_zeros(z)
+    end
+    return Y
+end
+
+function conductance_per_length(pc::ParallelConductor, phase_type::Type{T}) where {T <: Phases}
+    y = _parallel_admittance(pc, phase_type)
+    g = real(y) / pc.length
+    return g
+end
+
+function conductance(pc::ParallelConductor, phase_type::Type{T}) where {T <: Phases}
+    real(_parallel_admittance(pc, phase_type))
+end
+
+function susceptance_per_length(pc::ParallelConductor, phase_type::Type{T}) where {T <: Phases}
+    y = _parallel_admittance(pc, phase_type)
+    b = imag(y) / pc.length
+    return b
+end
+
+function susceptance(pc::ParallelConductor, phase_type::Type{T}) where {T <: Phases}
+    imag(_parallel_admittance(pc, phase_type))
+end
+
 
 """
     conductance(vr::VoltageRegulator)

--- a/src/edges/conductors.jl
+++ b/src/edges/conductors.jl
@@ -117,6 +117,22 @@ is used to define `ShuntAdmittance` values for busses.
     amps_limit::Union{Real, Missing} = missing
 end
 
+mutable struct ParallelConductor <: AbstractEdge
+    busses::Tuple{String, String}
+    conductors::Vector{Conductor}
+    phases::Union{Vector{Int}, Missing}
+    length::Real
+    function ParallelConductor(cs::Vector{Conductor})
+        @assert !isempty(cs)
+        busses = cs[1].busses
+        @assert all(c -> c.busses == busses, cs)
+        phs = [c.phases for c in cs if !ismissing(c.phases)]
+        phases = isempty(phs) ? missing : sort(unique(reduce(vcat, phs)))
+        len = mean(c.length for c in cs)
+        new(busses, cs, phases, len)
+    end
+end
+
 
 """
     check_edges!(conductors::AbstractVector{Conductor})

--- a/src/network_reduction.jl
+++ b/src/network_reduction.jl
@@ -20,9 +20,10 @@ function reduce_tree!(net::Network)
         edge_jk = net[(bus, j_to_k(bus, net)[1])]
         phases_ij = ismissing(edge_ij.phases) ? [1] : edge_ij.phases
         phases_jk = ismissing(edge_jk.phases) ? [1] : edge_jk.phases
-        if ( # we have two and only two conductors at the bus and phases match
-            !(bus in ld_busses) && 
-            typeof(edge_ij) == CommonOPF.Conductor == typeof(edge_jk) &&
+        if (
+            !(bus in ld_busses) &&
+            (edge_ij isa CommonOPF.Conductor || edge_ij isa CommonOPF.ParallelConductor) &&
+            (edge_jk isa CommonOPF.Conductor || edge_jk isa CommonOPF.ParallelConductor) &&
             phases_ij == phases_jk
         )
             push!(reducable_buses, bus)
@@ -49,7 +50,8 @@ function remove_bus!(j::String, net::Network{SinglePhase})
     # get all the old values
     i, k = i_to_j(j, net)[1], j_to_k(j, net)[1]
     c1, c2 = net[(i, j)], net[(j, k)]
-    @assert typeof(c1) == CommonOPF.Conductor == typeof(c2) "remove_bus! can only combine two conductors"
+    @assert (c1 isa CommonOPF.Conductor || c1 isa CommonOPF.ParallelConductor) &&
+            (c2 isa CommonOPF.Conductor || c2 isa CommonOPF.ParallelConductor) "remove_bus! can only combine two conductors"
     # make the new values
     r_ik = resistance(c1, network_phase_type(net)) + resistance(c2, network_phase_type(net))
     x_ik = reactance(c1, network_phase_type(net))  + reactance(c2, network_phase_type(net))
@@ -90,7 +92,8 @@ function remove_bus!(j::String, net::Network{MultiPhase})
     # get all the old values
     i, k = i_to_j(j, net)[1], j_to_k(j, net)[1]
     c1, c2 = net[(i, j)], net[(j, k)]
-    @assert typeof(c1) == CommonOPF.Conductor == typeof(c2) "remove_bus! can only combine two conductors"
+    @assert (c1 isa CommonOPF.Conductor || c1 isa CommonOPF.ParallelConductor) &&
+            (c2 isa CommonOPF.Conductor || c2 isa CommonOPF.ParallelConductor) "remove_bus! can only combine two conductors"
     @assert c1.phases == c2.phases "remove_bus! only works with two conductors that have matching phases"
     # make the new values
     rmatrix_ik = resistance(c1, network_phase_type(net)) + resistance(c2, network_phase_type(net))

--- a/test/test_network.jl
+++ b/test/test_network.jl
@@ -189,5 +189,33 @@ end
         MOI.EqualTo{ComplexF64},
         (CommonOPF.BusDimension, CommonOPF.TimeDimension, CommonOPF.PhaseDimension),
     )
-    print_constraint_info(net)
+print_constraint_info(net)
+end
+
+@testset "parallel conductors" begin
+    net_dict_parallel = Dict(
+        :Network => Dict(:substation_bus => "a"),
+        :Conductor => [
+            Dict(:busses => ("a", "b"), :length => 1, :r1 => 1.0, :x1 => 1.0),
+            Dict(:busses => ("a", "b"), :length => 1, :r1 => 1.0, :x1 => 1.0),
+            Dict(:busses => ("b", "c"), :length => 1, :r1 => 0.5, :x1 => 0.5),
+        ],
+        :Load => [Dict(:bus => "c", :kws1 => [1.0])],
+    )
+    net_p = Network(net_dict_parallel)
+    @test net_p[("a", "b")] isa CommonOPF.ParallelConductor
+
+    net_dict_single = Dict(
+        :Network => Dict(:substation_bus => "a"),
+        :Conductor => [
+            Dict(:busses => ("a", "b"), :length => 1, :r1 => 0.5, :x1 => 0.5),
+            Dict(:busses => ("b", "c"), :length => 1, :r1 => 0.5, :x1 => 0.5),
+        ],
+        :Load => [Dict(:bus => "c", :kws1 => [1.0])],
+    )
+    net_s = Network(net_dict_single)
+    reduce_tree!(net_p)
+    reduce_tree!(net_s)
+    @test rij("a", "c", net_p) ≈ rij("a", "c", net_s)
+    @test xij("a", "c", net_p) ≈ xij("a", "c", net_s)
 end


### PR DESCRIPTION
## Summary
- introduce `ParallelConductor` edge type that groups multiple conductors
- compute impedance/admittance for `ParallelConductor`
- detect duplicate conductors when building graphs and networks
- handle parallel conductors in Network API and reduction routines
- document parallel line capability and update developer notes
- add regression tests for parallel conductors

## Testing
- `julia --project=@. -e 'using Pkg; Pkg.test()'` *(fails: could not download registry)*

------
https://chatgpt.com/codex/tasks/task_b_68604c39b908832fa5652398de591a6c