### PR TITLE
Add support for optional ParallelConductor

### DIFF
--- a/docs/src/network.md
+++ b/docs/src/network.md
@@ -13,8 +13,9 @@ include:
 - [VoltageRegulator](@ref)
 - [Transformer](@ref)
 
-Duplicate conductor entries between the same pair of busses are automatically
-stored as a `ParallelConductor`. Impedance and admittance functions treat a
+Duplicate conductor entries between the same pair of busses can be merged into a
+`ParallelConductor` by passing `allow_parallel_conductor=true` when building the
+[`Network`](@ref). Impedance and admittance functions treat a
 `ParallelConductor` the same as a single conductor whose parameters are the
 parallel combination of the contained lines.
 

--- a/src/adapters/opendss.jl
+++ b/src/adapters/opendss.jl
@@ -236,13 +236,14 @@ end
 
 
 """
+    dss_to_Network(dssfilepath::AbstractString; allow_parallel_conductor::Bool=false)::Network
 
-    dss_to_Network(dssfilepath::AbstractString)::Network
-
-Using a OpenDSS command to compile the `dssfilepath` we load in the data from .dss files and parse
-the data into a `Network` model.
+Using a OpenDSS command to compile `dssfilepath` we load in the data from `.dss`
+files and parse the data into a [`Network`](@ref). Set
+`allow_parallel_conductor=true` to merge duplicate lines between the same pair of
+busses.
 """
-function dss_to_Network(dssfilepath::AbstractString)::Network
+function dss_to_Network(dssfilepath::AbstractString; allow_parallel_conductor::Bool=false)::Network
     # OpenDSS changes the working directory, so we need to change it back
     work_dir = pwd()
     OpenDSS.dss("""
@@ -278,7 +279,7 @@ function dss_to_Network(dssfilepath::AbstractString)::Network
     # equal to the inputs, i.e. the load model=1 for constant power and the vmin/maxpu values were
     # not violated, which causes the load model to change in OpenDSS)
 
-    Network(net_dict)
+    Network(net_dict; allow_parallel_conductor=allow_parallel_conductor)
 end
 
 

--- a/src/adapters/psse.jl
+++ b/src/adapters/psse.jl
@@ -257,12 +257,12 @@ end
 
 
 """
-    psse_to_Network(fp::AbstractString)::Network
+    psse_to_Network(fp::AbstractString; allow_parallel_conductor::Bool=false)::Network
 
 Parse a PSS/E RAW file and convert it into a [`Network`](@ref). Only version 33
-RAW files are supported.
+RAW files are supported. Set `allow_parallel_conductor=true` to merge duplicate lines between the same pair of busses.
 """
-function psse_to_Network(fp::AbstractString)::Network
+function psse_to_Network(fp::AbstractString; allow_parallel_conductor::Bool=false)::Network
     lines = readlines(fp)
 
     header = split(lines[1], ",")
@@ -297,6 +297,6 @@ function psse_to_Network(fp::AbstractString)::Network
         :Load => loads,
     )
 
-    Network(net_dict)
+    Network(net_dict; allow_parallel_conductor=allow_parallel_conductor)
 end
 

--- a/src/edges/admittances.jl
+++ b/src/edges/admittances.jl
@@ -268,6 +268,11 @@ function susceptance(c::Conductor, phase_type::Type{T}) where {T <: Phases}
     susceptance_per_length(c, phase_type) * c.length
 end
 
+"""
+    _parallel_admittance(pc::ParallelConductor, phase_type::Type{SinglePhase})
+
+Admittance of multiple conductors in parallel for a single phase network.
+"""
 function _parallel_admittance(pc::ParallelConductor, phase_type::Type{SinglePhase})
     y = zero(ComplexF64)
     for c in pc.conductors
@@ -277,6 +282,11 @@ function _parallel_admittance(pc::ParallelConductor, phase_type::Type{SinglePhas
     return y
 end
 
+"""
+    _parallel_admittance(pc::ParallelConductor, phase_type::Type{MultiPhase})
+
+Admittance matrix of parallel conductors for a multiphase network.
+"""
 function _parallel_admittance(pc::ParallelConductor, phase_type::Type{MultiPhase})
     Y = zeros(ComplexF64, 3, 3)
     for c in pc.conductors

--- a/src/edges/conductors.jl
+++ b/src/edges/conductors.jl
@@ -118,6 +118,14 @@ is used to define `ShuntAdmittance` values for busses.
 end
 
 
+"""
+    @with_kw mutable struct ParallelConductor <: AbstractEdge
+
+Store multiple [`Conductor`](@ref) objects that share the same pair of busses.
+Impedance and admittance functions operate on a `ParallelConductor` just like on
+a single conductor whose parameters are the parallel combination of the contained
+lines.
+"""
 @with_kw mutable struct ParallelConductor <: AbstractEdge
     busses::Tuple{String, String}
     conductors::Vector{Conductor} = Vector{Conductor}[]
@@ -126,6 +134,13 @@ end
 end
 
 
+"""
+    ParallelConductor(cs::Vector{Conductor})
+
+Create a [`ParallelConductor`](@ref) from a vector of `Conductor` objects. All
+conductors must share the same pair of busses. The phases are the union of the
+phases on the contained lines and the length is the mean length of the lines.
+"""
 function ParallelConductor(cs::Vector{Conductor})
     @assert !isempty(cs)
     busses = cs[1].busses

--- a/src/edges/impedances.jl
+++ b/src/edges/impedances.jl
@@ -207,6 +207,12 @@ end
 """
 
 """
+    _parallel_impedance(pc::ParallelConductor, phase_type::Type{SinglePhase})
+
+Return the impedance of multiple conductors connected in parallel. For single
+phase lines this is the scalar impedance of the parallel combination of all
+lines in `pc`.
+"""
 function _parallel_impedance(pc::ParallelConductor, phase_type::Type{SinglePhase})
     y = zero(ComplexF64)
     for c in pc.conductors
@@ -216,6 +222,12 @@ function _parallel_impedance(pc::ParallelConductor, phase_type::Type{SinglePhase
     return 1 / y
 end
 
+"""
+    _parallel_impedance(pc::ParallelConductor, phase_type::Type{MultiPhase})
+
+Return the impedance matrix of multiple conductors connected in parallel for a
+multiphase network.
+"""
 function _parallel_impedance(pc::ParallelConductor, phase_type::Type{MultiPhase})
     Y = zeros(ComplexF64, 3, 3)
     for c in pc.conductors

--- a/test/test_conductor.jl
+++ b/test/test_conductor.jl
@@ -50,8 +50,34 @@
         pc = CommonOPF.ParallelConductor([c1])
         @test CommonOPF.resistance(c1, CommonOPF.SinglePhase) ≈ CommonOPF.resistance(pc, CommonOPF.SinglePhase)
         @test CommonOPF.reactance(c1, CommonOPF.SinglePhase) ≈ CommonOPF.reactance(pc, CommonOPF.SinglePhase)
+        z = CommonOPF._parallel_impedance(pc, CommonOPF.SinglePhase)
+        y = CommonOPF._parallel_admittance(pc, CommonOPF.SinglePhase)
+        @test z ≈ (1 + 1im) / 2
+        @test y ≈ 2 / (1 + 1im)
+        @test CommonOPF.resistance_per_length(pc, CommonOPF.SinglePhase) == real(z)
+        @test CommonOPF.reactance_per_length(pc, CommonOPF.SinglePhase) == imag(z)
+        @test CommonOPF.conductance_per_length(pc, CommonOPF.SinglePhase) == real(y)
+        @test CommonOPF.susceptance_per_length(pc, CommonOPF.SinglePhase) == imag(y)
     end
     
+end
+
+@testset "ParallelConductor multiphase" begin
+    c1 = CommonOPF.Conductor(
+        busses=("a","b"),
+        phases=[1,2,3],
+        rmatrix=Matrix{Float64}(I,3,3),
+        xmatrix=Matrix{Float64}(I,3,3),
+        length=1.0,
+    )
+    c2 = deepcopy(c1)
+    pc = CommonOPF.ParallelConductor([c1,c2])
+    z = CommonOPF._parallel_impedance(pc, CommonOPF.MultiPhase)
+    y = CommonOPF._parallel_admittance(pc, CommonOPF.MultiPhase)
+    expected_z = ((1 + 1im)/2) * Matrix{ComplexF64}(I,3,3)
+    expected_y = (2/(1+1im)) * Matrix{ComplexF64}(I,3,3)
+    @test all(z .≈ expected_z)
+    @test all(y .≈ expected_y)
 end
 
 

--- a/test/test_network.jl
+++ b/test/test_network.jl
@@ -202,7 +202,8 @@ end
         ],
         :Load => [Dict(:bus => "c", :kws1 => [1.0])],
     )
-    net_p = Network(net_dict_parallel)
+    @test_throws ArgumentError Network(net_dict_parallel)
+    net_p = Network(net_dict_parallel; allow_parallel_conductor=true)
     @test net_p[("a", "b")] isa CommonOPF.ParallelConductor
 
     net_dict_single = Dict(

--- a/test/test_psse.jl
+++ b/test/test_psse.jl
@@ -9,7 +9,7 @@
     first_tr = first(trs)
     @test isapprox(first_tr[:reactance], 0.02670 * (138^2 / 100); atol=1e-6)
 
-    net = CommonOPF.psse_to_Network(fp)
+    net = CommonOPF.psse_to_Network(fp; allow_parallel_conductor=true)
     @test net.substation_bus == "1"
     @test length(conductors(net)) == length(cds)
     @test net["1"][:Load].kws1 == [17000.0]


### PR DESCRIPTION
## Summary
- add `allow_parallel_conductor` keyword to network builders and adapters
- document and implement merging of parallel conductors
- expand docs on parallel conductor usage
- provide docstrings for parallel conductor utilities
- update tests for parallel conductor support and add new coverage

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: could not download registries)*

------
https://chatgpt.com/codex/tasks/task_b_686134208b3c832fb52be648e9008878